### PR TITLE
Improve Message Delete Logic

### DIFF
--- a/src/functions/discord/deletePreviousMessages.ts
+++ b/src/functions/discord/deletePreviousMessages.ts
@@ -6,10 +6,12 @@ export default async function deletePreviousMessages(
 	env: Env,
 ): Promise<void> {
 	const emptyResponse = 204;
+	const auditLogReason = "Regular Channel Message Cleanup by Lamar (BOT)";
 
 	if (messages.length === 1) {
 		const headers = new Headers({
 			Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
+			"X-Audit-Log-Reason": auditLogReason,
 		});
 		const url = `https://discord.com/api/v${APIVersion}/channels/${env.DISCORD_CHANNEL_ID}/messages/${messages[0].id}`;
 		const init: RequestInit = {
@@ -24,6 +26,7 @@ export default async function deletePreviousMessages(
 		const headers = new Headers({
 			Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
 			"Content-Type": "application/json",
+			"X-Audit-Log-Reason": auditLogReason,
 		});
 
 		const messageIds: string[] = [];

--- a/src/functions/discord/deletePreviousMessages.ts
+++ b/src/functions/discord/deletePreviousMessages.ts
@@ -1,35 +1,47 @@
-import type {
-	RESTGetAPIChannelMessagesResult,
-	RESTPostAPIChannelMessagesBulkDeleteJSONBody,
-} from "discord-api-types/v10";
+import type { Env, RESTGetAPIChannelMessagesResult, RESTPostAPIChannelMessagesBulkDeleteJSONBody } from "../../types";
 import { APIVersion } from "../../const/discord/ourAPIVersion";
-import type { Env } from "../../types";
 
 export default async function deletePreviousMessages(
 	messages: RESTGetAPIChannelMessagesResult,
 	env: Env,
 ): Promise<void> {
 	const emptyResponse = 204;
-	const headers = new Headers({
-		Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
-		"Content-Type": "application/json",
-	});
 
-	const messageIds: string[] = [];
-	messages.forEach((message) => {
-		messageIds.push(message.id);
-	});
-	const payload: RESTPostAPIChannelMessagesBulkDeleteJSONBody = { messages: messageIds };
+	if (messages.length === 1) {
+		const headers = new Headers({
+			Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
+		});
+		const url = `https://discord.com/api/v${APIVersion}/channels/${env.DISCORD_CHANNEL_ID}/messages/${messages[0].id}`;
+		const init: RequestInit = {
+			method: "DELETE",
+			headers,
+		};
+		const response = await fetch(url, init);
+		if (response.status !== emptyResponse) {
+			throw new Error(`Error deleting previous message, status: ${response.status}`);
+		}
+	} else {
+		const headers = new Headers({
+			Authorization: `Bot ${env.DISCORD_BOT_TOKEN}`,
+			"Content-Type": "application/json",
+		});
 
-	const url = `https://discord.com/api/v${APIVersion}/channels/${env.DISCORD_CHANNEL_ID}/messages/bulk-delete`;
-	const init: RequestInit = {
-		method: "POST",
-		headers,
-		body: JSON.stringify(payload),
-	};
+		const messageIds: string[] = [];
+		messages.forEach((message) => {
+			messageIds.push(message.id);
+		});
+		const payload: RESTPostAPIChannelMessagesBulkDeleteJSONBody = { messages: messageIds };
 
-	const response = await fetch(url, init);
-	if (response.status !== emptyResponse) {
-		throw new Error(`Error deleting previous message, status: ${response.status}`);
+		const url = `https://discord.com/api/v${APIVersion}/channels/${env.DISCORD_CHANNEL_ID}/messages/bulk-delete`;
+		const init: RequestInit = {
+			method: "POST",
+			headers,
+			body: JSON.stringify(payload),
+		};
+
+		const response = await fetch(url, init);
+		if (response.status !== emptyResponse) {
+			throw new Error(`Error deleting previous message, status: ${response.status}`);
+		}
 	}
 }

--- a/src/types/discord/index.ts
+++ b/src/types/discord/index.ts
@@ -3,7 +3,9 @@ import type {
 	APIEmbed,
 	APIInteraction,
 	APIInteractionResponsePong,
+	RESTGetAPIChannelMessagesResult,
 	RESTPostAPIChannelMessageJSONBody,
+	RESTPostAPIChannelMessagesBulkDeleteJSONBody,
 	RESTPostAPIInteractionCallbackJSONBody,
 	RESTPostAPIWebhookWithTokenJSONBody,
 } from "discord-api-types/v10";
@@ -14,6 +16,8 @@ export type {
 	APIInteraction,
 	APIInteractionResponsePong,
 	RESTPostAPIChannelMessageJSONBody,
+	RESTGetAPIChannelMessagesResult,
+	RESTPostAPIChannelMessagesBulkDeleteJSONBody,
 	RESTPostAPIInteractionCallbackJSONBody,
 	RESTPostAPIWebhookWithTokenJSONBody,
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,9 @@ import type {
 	APIEmbed,
 	APIInteraction,
 	APIInteractionResponsePong,
+	RESTGetAPIChannelMessagesResult,
 	RESTPostAPIChannelMessageJSONBody,
+	RESTPostAPIChannelMessagesBulkDeleteJSONBody,
 	RESTPostAPIInteractionCallbackJSONBody,
 	RESTPostAPIWebhookWithTokenJSONBody,
 } from "./discord/index";
@@ -41,6 +43,8 @@ export type {
 	LamarDialog,
 	LamarPhrases,
 	RESTPostAPIChannelMessageJSONBody,
+	RESTGetAPIChannelMessagesResult,
+	RESTPostAPIChannelMessagesBulkDeleteJSONBody,
 	RESTPostAPIInteractionCallbackJSONBody,
 	RESTPostAPIWebhookWithTokenJSONBody,
 	SteamUserInfo,


### PR DESCRIPTION
- Closes #15
- Lamar now calls Discord's Delete Channel Message endpoint if there's only one message in the channel.
- An Audit Log reason is now provided for delete operations.
